### PR TITLE
Use latest versions for dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@ source "https://rubygems.org"
 
 gem "gosu"
 gem "ruby-opengl"
+gem "glu"
+gem "glut"
 gem "json"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    glu (8.2.0)
+    glut (8.2.0)
     gosu (0.7.50)
     json (1.8.1)
     opengl (0.9.0)
@@ -11,6 +13,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  glu
+  glut
   gosu
   json
   ruby-opengl


### PR DESCRIPTION
Because the lessons don't work on Ruby 2.0.0 or later.
